### PR TITLE
Bugfix: most recent call last

### DIFF
--- a/o365_usertokens
+++ b/o365_usertokens
@@ -109,6 +109,11 @@ if __name__ == '__main__':
 					logger.info("Modified %s users, exiting", modified_users)
 					exit(0)
 
+				if ldap_user[1].has_key("univentionOffice365Data"):
+                                    pass
+                                else:
+                                    continue
+
 				adconnection_objects = Office365Listener.decode_o365data(ldap_user[1]["univentionOffice365Data"][0])
 				for alias, values in adconnection_objects.items():
 					ah = AzureHandler(ucr, name = "tokens", adconnection_alias = alias)


### PR DESCRIPTION
CronJob `/etc/cron.d/univention-office365-tokens` fails.
Users who have not been logged in for a long time (vacation or short-time work in german Kurzarbeit) do not have the `univentionOffice365Data` attribute.
The CronJob try to access these non existing attribute and ends with the following error message:

```
Traceback (most recent call last):
File "/usr/share/univention-office365/scripts/o365_usertokens", line 112, in <module>
adconnection_objects = Office365Listener.decode_o365data(ldap_user[1]["univentionOffice365Data"][0])
KeyError: 'univentionOffice365Data'
```